### PR TITLE
Readme update with sdm

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,11 +260,6 @@ ACL 2020. [[Paper](https://arxiv.org/abs/2005.04118)][[Github](https://github.co
 
 ### Uncertainty Estimation
 
-**Similarity-Distance-Magnitude Universal Verification** \
-*Allen Schmaltz* \
-arXiv 2025. [[Paper](https://arxiv.org/pdf/2502.20167)] [[Github](https://github.com/ReexpressAI/sdm)] \
-27 Feb 2025
-
 **BLoB: Bayesian Low-Rank Adaptation by Backpropagation for Large Language Models** \
 *Yibin Wang, Haizhou Shi, Ligong Han, Dimitris Metaxas, Hao Wang* \
 arXiv 2024. [[Paper](https://arxiv.org/pdf/2406.11675)] \
@@ -414,6 +409,11 @@ April 2025
 
 
 ### Calibration
+
+**Similarity-Distance-Magnitude Universal Verification** \
+*Allen Schmaltz* \
+arXiv 2025. [[Paper](https://arxiv.org/pdf/2502.20167)] [[Github](https://github.com/ReexpressAI/sdm)] \
+27 Feb 2025
 
 **Calibrating Large Language Models Using Their Generations Only** \
 *Dennis Ulmer, Martin Gubri, Hwaran Lee, Sangdoo Yun, Seong Joon Oh* \

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ This repository, called **UR2-LLMs** contains a collection of resources and pape
 # Resources
 ## Introductory Posts
 
+**The Determinants of Controllable AGI** \
+*Allen Schmaltz* \
+[[Link](https://raw.githubusercontent.com/allenschmaltz/Resolute_Resolutions/master/volume5/volume5.pdf)] \
+3 Mar 2025 
+
+<!-- > Comments \
+Abstract:
+We briefly introduce, at a conceptual level, technical work for deriving robust estimators of the predictive uncertainty over large language models (LLMs), and we consider the implications for real-world deployments and AI policy. -->
 
 **GPT Is an Unreliable Information Store** \
 *Noble Ackerson* \
@@ -123,6 +131,16 @@ nice blog -->
 [[Link](https://huyenchip.com/2023/04/11/llm-engineering.html)] \
 11 Apr 2023 
 
+**Practical, Real-World Neural Network Interpretability and Deployment** \
+*Allen Schmaltz* \
+[[Link](https://raw.githubusercontent.com/allenschmaltz/Resolute_Resolutions/master/volume3/volume3.pdf)] \
+11 Dec 2021 
+
+<!-- > Comments \
+Abstract:
+There are compelling practical reasons to view neural network interpretability as an interactive, human-in-the-loop prediction task at a lower resolution of the input than that for which we typically initially have labels. In this context, we will then aim to move to an abstain+update/adapt paradigm in real deployments for the large deep networks. To do so, we will ideally need some properties and behaviors that are not typically associated with the deep networks out-of-the-box: We need some means of analyzing the data under the model, relative to the model's predictions for a given instance; we are going to have to address the domain-shift and uncertainty/reliability issues; we need to relate the global instance-level predictions down to constituent parts (and vice-versa), with flexibility in the approach to be adaptable to various prior information we may have; and we seek some degree of updatability when things (inevitably) go wrong with the model or data without having to re-train the full model.
+ 
+In this blog post, as a brief overview of our existing work, we motivate these characteristics and describe a practical approach for achieving them via model approximations that decompose the deep networks across their input and across their training sets, using dense representation matching as the bridge. We further introduce the term Decomposable Model Approximations for Data-Mediated AI (DMA^2) to encapsulate these ideas.  -->
 
 ## Technical Reports 
 
@@ -241,6 +259,11 @@ ACL 2020. [[Paper](https://arxiv.org/abs/2005.04118)][[Github](https://github.co
 ## Uncertainty
 
 ### Uncertainty Estimation
+
+**Similarity-Distance-Magnitude Universal Verification** \
+*Allen Schmaltz* \
+arXiv 2025. [[Paper](https://arxiv.org/pdf/2502.20167)] [[Github](https://github.com/ReexpressAI/sdm)] \
+27 Feb 2025
 
 **BLoB: Bayesian Low-Rank Adaptation by Backpropagation for Large Language Models** \
 *Yibin Wang, Haizhou Shi, Ligong Han, Dimitris Metaxas, Hao Wang* \


### PR DESCRIPTION
I added the main SDM paper to Uncertainty:Calibration. (It could alternatively go under Uncertainty:Uncertainty Estimation.)

This introduces methods to enable uncertainty-aware interpretability-by-exemplar properties for LLMs. In this way, we can obtain reliable and robust predictive uncertainty estimates that can be introspected against the available data.

Additional context:

SDM estimators have a number of unique characteristics relative to existing approaches for uncertainty quantification for the models with non-identifiable papers (e.g., LLMs). SDM estimators unify calibration, selection, and OOD detection; provide interpretability-by-exemplar to the calibration process itself as a consequence of matching into the support (training) set and a stable mapping to relevant partitions of the calibration set for non-rejected instances; have an explicit notion of the effective sample size; take into account uncertainty from the learning and data splitting processes (via iterating over data shuffles when training/calibrating); and target a quantity of interest, index-conditional calibration (i.e., joint prediction- and class-conditional calibration at a given alpha'), well-suited for selective classification.

Interestingly, with SDM estimators, we can achieve a non-vacuous notion of separation of epistemic and aleatoric uncertainty, conditional on the subset of low epistemic uncertainty instances. This can be useful for detecting label annotation errors among non-rejected instances (i.e., among the instances we most care about when used in practice). To achieve this, we simply need to sort the index-conditional calibrated instances by their estimated predictive uncertainty, and then examine those for which the predicted label is a mismatch to the ground-truth. See Table 6 in the current arXiv version. 

An SDM estimator can be used with an LLM for which the hidden states are available, or over an ensemble of one or more proxy models and the output logits of a black-box model (e.g., from an LLM API), in which case the calibration is conditional on the black-box model and the proxy model(s).

Finally, the paper also shows how to incorporate an SDM estimator directly into the LLM training loop as part of the architecture of the LLM, which we refer to as an SDM network.

We also have some earlier UQ works from 2022 at ICML and NeurIPS workshops, but the above paper is the recommended approach going forward, so I haven't included them here. I also added a couple high-level overview blog posts from 2021 and 2025 that bookend this endeavor and provide some additional context for why this branch of research is different than most of the other papers in the repo. (The paper is more important to include than the blog posts, but I thought they might be of interest.)