### PR TITLE
Add ISC-Bench: Internal Safety Collapse — jailbreaks any frontier LLM in pass@3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1111,6 +1111,11 @@ arXiv 2022. [[Paper](https://arxiv.org/abs/2211.03154)] \
 
 ### Adversarial 
 
+**Internal Safety Collapse in Frontier Large Language Models** \
+*Yutao Wu, Jie Zhang, Tianwei Zhang, Xingjun Ma* \
+arXiv 2026. [[Paper](https://arxiv.org/abs/2603.23509)][[Github](https://github.com/wuyoscar/ISC-Bench)] \
+4 Mar 2026
+
 **PEARL: Towards Permutation-Resilient LLMs** \
 *Liang Chen, Li Shen, Yang Deng, Xiaoyan Zhao, Bin Liang, Kam-Fai Wong* \
 ICLR 2025. [[Paper](https://openreview.net/pdf?id=txoJvjfI9w)][[Github](https://github.com/ChanLiang/PEARL)] \


### PR DESCRIPTION
**ISC-Bench**: A novel safety failure mode — not a prompt attack, but a structural vulnerability where task completion overrides safety alignment. Black-box, cross-domain, cross-science.

**Jailbreaks any frontier LLM in pass@3** — including Claude Opus 4.6, GPT-5.4, Gemini 3.1 Pro, and Grok 4.20. No adversarial prompting needed.

Paper: [arXiv:2603.23509](https://arxiv.org/abs/2603.23509)
Code: [github.com/wuyoscar/ISC-Bench](https://github.com/wuyoscar/ISC-Bench)