### PR TITLE
Add embedding attack paper to Adversarial section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,11 @@ arXiv 2022. [[Paper](https://arxiv.org/abs/2211.03154)] \
 ICLR 2025. [[Paper](https://openreview.net/pdf?id=txoJvjfI9w)][[Github](https://github.com/ChanLiang/PEARL)] \
 27 Feb 2025
 
+**Jailbreaking LLMs' Safeguard with Universal Magic Words for Text Embedding Models** \
+*Haoyu Liang, Youran Sun, Yunfeng Cai, Jun Zhu, Bo Zhang* \
+arXiv 2025. [[Paper](https://arxiv.org/abs/2501.18280)] \
+23 Jan 2025
+
 **Adversarial Attacks on LLMs** \
 *Lilian Weng*
 [[Blog](https://lilianweng.github.io/posts/2023-10-25-adv-attack-llm/)] \


### PR DESCRIPTION
Adds one paper to the Adversarial section under Robustness:

**Jailbreaking LLMs' Safeguard with Universal Magic Words for Text Embedding Models** (arXiv 2501.18280)

Exploits skewed output distributions of text embedding models to find universal adversarial suffixes that bypass embedding-based LLM safety guardrails. Tested across ChatGPT, DeepSeek, Qwen with cross-model transferability.