### PR TITLE
Add Cognometry v0 — 8-benchmark cross-validated hallucination detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,10 @@ COLING 2020. [[Paper](https://arxiv.org/abs/2012.02462)] \
 ### Hallucination
 > [awesome hallucination detection](https://github.com/EdinburghNLP/awesome-hallucination-detection)
 
+**Cognometry v0: 8-Benchmark Cross-Validated Hallucination Detection in Production LLMs** \
+Introduces *cognometry* — the empirical measurement of cognitive states in LLMs. 9-signal pooled LR (text, entity, knowledge grounding, 4 response-novelty variants, NLI contradiction via DeBERTa-v3-base-mnli) cross-validated on 8 benchmarks (HaluEval QA/Dialog/Summ, TruthfulQA, HaluBench DROP/PubMedQA/FinanceBench/RAGTruth). AUC 0.998 on HaluEval-QA; two below-chance results (DROP, FinanceBench) declared as published failure modes in the weights module. \
+[[Paper](https://doi.org/10.5281/zenodo.19703527)] [[Code](https://github.com/fathom-lab/styxx)] [[Manifesto](https://fathom.darkflobi.com/cognometry)]
+
 **DRIFT: Detecting Representational Inconsistencies for Factual Truthfulness** \
 *Rohan Bhatnagar, Youran Sun, Chi Andrew Zhang, Yixin Wen, Haizhao Yang* \
 arXiv 2026. [[Paper](https://arxiv.org/abs/2601.14210)] \


### PR DESCRIPTION
Adding **Cognometry v0** to Reliability > Hallucination. First open-source
hallucination detector cross-validated across 8 public benchmarks with
3-seed-averaged AUCs.

Headline: AUC 0.998 on HaluEval-QA, 0.994 on TruthfulQA, 0.807 on
HaluBench-RAGTruth. **Two failure modes declared openly** in the weights
module (HaluBench-DROP 0.424, HaluBench-FinanceBench 0.492 — below chance,
with structural explanation).

Just merged by @pminervini into `EdinburghNLP/awesome-hallucination-detection`
(#55), thought it belonged here too given the Reliability framing.

Paper: https://doi.org/10.5281/zenodo.19703527
Code: https://github.com/fathom-lab/styxx (MIT + CC-BY-4.0)
