### PR TITLE
Add FG tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This repository, called **UR2-LLMs** contains a collection of resources and pape
     - [Active Learning](#active-learning)
   - [Reliability](#reliability)
     - [Hallucination](#hallucination)
+    - [Mechanistic Interpretability](#mechanistic-interpretability)
     - [Truthfulness](#truthfulness)
     - [Reasoning](#reasoning)
     - [Prompt tuning, optimization and design](#prompt-tuning-optimization-and-design)
@@ -784,6 +785,14 @@ TACL 2022. [[Paper](https://arxiv.org/abs/2204.10757)] \
 *Ziwei Ji, Nayeon Lee, Rita Frieske, Tiezheng Yu, Dan Su, Yan Xu, Etsuko Ishii, Yejin Bang, Wenliang Dai, Andrea Madotto, Pascale Fung* \
 arXiv 2022. [[Paper](https://arxiv.org/abs/2202.03629)] \
 8 Feb 2022
+
+
+### Mechanistic Interpretability
+
+**FG-TRACER: Tracing Information Flow in Multimodal Large Language Models in Free-Form Generation** \
+*Alessia Saporita, Vittorio Pipoli, Federico Bolelli, Lorenzo Baraldi, Andrea Acquaviva, Elisa Ficarra* \
+WACV 2026. [[Paper](https://iris.unimore.it/handle/11380/1390068)] [[Github](https://github.com/aimagelab/FG-TRACER)] \
+Introduces a mechanistic interpretability framework for tracing cross-modal information flow between visual and textual modalities in MLLMs during free-form generation, leveraging attention masking interventions and a novel stable formulation for quantifying information flow.
 
 
 ### Truthfulness 


### PR DESCRIPTION
This PR adds FG-TRACER, a framework for tracing information flow in Multimodal Large Language Models (MLLMs) during free-form generation tasks.

FG-TRACER introduces a numerically stabilized methodology to analyze interactions between visual and textual modalities through targeted attention masking and probability-based information flow estimation. Unlike prior approaches mainly focused on short-answer VQA settings, FG-TRACER extends multimodal tracing to underexplored generation tasks such as image captioning and chain-of-thought reasoning.

Highlights
- Numerically stabilized probability normalization for long-form outputs
- Support for multiple MLLMs:mLLaVA 1.5, LLaMA 3.2-Vision, Qwen 2.5-VL
- Evaluation on: TextVQA, COCO2014, ChartQA
- Word-level multimodal grounding analysis

FG-TRACER: Tracing Information Flow in Multimodal Large Language Models in Free-Form Generation (WACV 2026).